### PR TITLE
Deploy using github actions to a test digitalocean cluster

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,10 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -17,7 +21,7 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3
         with:
           images: ghcr.io/smirl/digitalocean-floating-ip-controller
 
@@ -32,7 +36,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,13 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+    needs:
+      - build
+    steps:
       - name: Get tag name
         uses: olegtarasov/get-tag@v2.1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,3 +41,27 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+
+      - name: Get tag name
+        uses: olegtarasov/get-tag@v2.1
+
+      - uses: azure/setup-kubectl@v1
+        with:
+          version: 'v1.19.4'
+
+      - uses: imranismail/setup-kustomize@v1
+        with:
+          kustomize-version: "4.0.5"
+
+      - uses: azure/k8s-set-context@v1
+        with:
+          method: service-account
+          k8s-url: ${{ secrets.K8S_URL }}
+          k8s-secret: ${{ secrets.K8S_SECRET }}
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15.10'
+
+      - name: Deploy
+        run: IMG=ghcr.io/smirl/digitalocean-floating-ip-controller:$GIT_TAG_NAME make deploy

--- a/README.md
+++ b/README.md
@@ -45,12 +45,27 @@ Currently supported policies are:
 
 ### Installation
 
-TODO
+The controller can be deployed from this repo with:
+
+```console
+IMG=ghcr.io/smirl/digitalocean-floating-ip-controller:v0.1.0 make deploy
+```
 
 ### Controller Configuration
 You **must** provide the following as *environment variables*:
 - `DO_TOKEN`
   - DigitalOcean API token
+
+
+## Contributing
+
+Please feel free to raise an issue or pull request. Releases automattically
+build and deploy to a test cluster. The github workflow requires the ServiceAccount
+to be deployed into the cluster and the token added as a repository secret.
+
+```console
+kubectl apply -f serviceaccount.yaml
+```
 
 [DOKS]: https://www.digitalocean.com/products/kubernetes/
 [bash]: https://github.com/mwthink/digitalocean-floating-ip-controller

--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ You **must** provide the following as *environment variables*:
 - `DO_TOKEN`
   - DigitalOcean API token
 
+This is taken from a secret called `do-floating-ip-controller` which must be
+added to the cluster.
 
 ## Contributing
 
-Please feel free to raise an issue or pull request. Releases automattically
+Please feel free to raise an issue or pull request. Releases automatically
 build and deploy to a test cluster. The github workflow requires the ServiceAccount
 to be deployed into the cluster and the token added as a repository secret.
 

--- a/serviceaccount.yaml
+++ b/serviceaccount.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: do-floating-ip-controller-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-actions
+  namespace: do-floating-ip-controller-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: github-actions
+  namespace: do-floating-ip-controller-system
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - secrets
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: github-actions
+  namespace: do-floating-ip-controller-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: github-actions
+subjects:
+- kind: ServiceAccount
+  name: github-actions
+  namespace: do-floating-ip-controller-system


### PR DESCRIPTION
# Summary

- Add a service account file which allows actions to deploy
- add github job to deploy
- add prod environment for secrets
- use GITHUB_TOKEN not DOCKER_TOKEN for ghcr.io