### PR TITLE
Change the resources that the manager container requires

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,11 +51,11 @@ spec:
               name: do-floating-ip-controller
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 128Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 50m
+            memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       priorityClassName: priority-class


### PR DESCRIPTION
# Summary

We are seeing that the pod is using way less CPU that 100m on average.
However, there are times that it uses ~20Mb of ram which triggers alerts. Less be less tight with Memory.

![image](https://user-images.githubusercontent.com/5792870/234549695-23251fdc-c080-4be8-9880-1a2d92be0795.png)
